### PR TITLE
Fix GTK starter

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -3481,6 +3481,7 @@ int app_main(int argc, char const * const argv[])
         char dirpath[BMAX_PATH+1];
 
         // the OSX app bundle, or on Windows the directory where the EXE was launched
+        // on Linux/*BSD directory of the executable
         if (appdir) {
             addsearchpath(appdir);
             free(appdir);

--- a/src/startgtk.game.c
+++ b/src/startgtk.game.c
@@ -22,7 +22,7 @@
 #include "types.h"
 #include "build.h"
 #include "baselayer.h"
-#include "startdlg.h"
+#include "grpscan.h"
 
 #define TAB_CONFIG 0
 #define TAB_GAME 1


### PR DESCRIPTION
jfsw couldn't be compiled with the GTK starter anymore because startdlg.h was removed and its contents are now in grpscan.h, so I changed that.

There is also one line referring to changes from jonof/jfbuild#5
