### PR TITLE
Use grpscan.h instead of strdlg.h

### DIFF
--- a/src/startgtk.game.c
+++ b/src/startgtk.game.c
@@ -22,7 +22,7 @@
 #include "types.h"
 #include "build.h"
 #include "baselayer.h"
-#include "startdlg.h"
+#include "grpscan.h"
 
 #define TAB_CONFIG 0
 #define TAB_GAME 1


### PR DESCRIPTION
The former doesn't exist in my checkout and it compiles cleanly with the former.
