### PR TITLE
Fixes to build on Raspberry Pi and latest jfbuild

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = ../jfmact.git
 [submodule "jfaudiolib"]
 	path = jfaudiolib
-	url = ../jfaudiolib.git
+	url = https://github.com/jonof/jfaudiolib.git
 [submodule "jfbuild"]
 	path = jfbuild
-	url = ../jfbuild.git
+	url = https://github.com/jonof/jfbuild.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = ../jfmact.git
 [submodule "jfaudiolib"]
 	path = jfaudiolib
-	url = https://github.com/jonof/jfaudiolib.git
+	url = ../jfaudiolib.git
 [submodule "jfbuild"]
 	path = jfbuild
-	url = https://github.com/jonof/jfbuild.git
+	url = ../jfbuild.git

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ MACTROOT ?= jfmact
 # JFAudioLib source path
 AUDIOLIBROOT ?= jfaudiolib
 
+# Don't use x86 assembly on ARM
+ifneq (,$(shell uname -a | egrep 'arm|aarch64'))
+  NOASM ?= 1
+endif
+
 # Engine options
 SUPERBUILD ?= 1
 POLYMOST ?= 1
@@ -64,7 +69,7 @@ include $(AUDIOLIBROOT)/Makefile.shared
 CC=gcc
 CXX=g++
 OURCFLAGS=$(debug) -W -Wall -Wimplicit -Wno-unused \
-	-fno-pic -fno-strict-aliasing -DNO_GCC_BUILTINS \
+	-fPIC -fno-strict-aliasing -DNO_GCC_BUILTINS \
 	-I$(INC) -I$(EINC) -I$(MACTROOT) -I$(AUDIOLIBROOT)/include
 OURCXXFLAGS=-fno-exceptions -fno-rtti
 LIBS=-lm
@@ -209,6 +214,10 @@ alldarwin:
 endif
 
 all: sw$(EXESUFFIX) build$(EXESUFFIX)
+
+# from jfbuild/Makefile, ideally should be moved to jfbuild/Makefile.shared:
+OURCFLAGS+= $(SDLCONFIG_CFLAGS)
+LIBS+= $(SDLCONFIG_LIBS)
 
 sw$(EXESUFFIX): $(GAMEOBJS) $(ELIB)/$(ENGINELIB) $(AUDIOLIBROOT)/$(JFAUDIOLIB)
 	$(CXX) $(CXXFLAGS) $(OURCXXFLAGS) $(OURCFLAGS) -o $@ $^ $(LIBS) $(GAMELIBS) -Wl,-Map=$@.map

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,8 @@ ifeq ($(PLATFORM),WINDOWS)
 endif
 
 ifeq ($(RENDERTYPE),SDL)
+	OURCFLAGS+= $(SDLCONFIG_CFLAGS)
+	LIBS+= $(SDLCONFIG_LIBS)
 	ifeq (1,$(HAVE_GTK2))
 		OURCFLAGS+= -DHAVE_GTK2 $(shell pkg-config --cflags gtk+-2.0)
 		GAMEOBJS+= $(SRC)/game_banner.$o $(SRC)/grpscan.$o $(SRC)/startgtk.game.$o
@@ -214,10 +216,6 @@ alldarwin:
 endif
 
 all: sw$(EXESUFFIX) build$(EXESUFFIX)
-
-# from jfbuild/Makefile, ideally should be moved to jfbuild/Makefile.shared:
-OURCFLAGS+= $(SDLCONFIG_CFLAGS)
-LIBS+= $(SDLCONFIG_LIBS)
 
 sw$(EXESUFFIX): $(GAMEOBJS) $(ELIB)/$(ENGINELIB) $(AUDIOLIBROOT)/$(JFAUDIOLIB)
 	$(CXX) $(CXXFLAGS) $(OURCXXFLAGS) $(OURCFLAGS) -o $@ $^ $(LIBS) $(GAMELIBS) -Wl,-Map=$@.map

--- a/src/StartupWinController.game.m
+++ b/src/StartupWinController.game.m
@@ -415,7 +415,7 @@ int startwin_idle(void *v)
 extern char* grpfile;
 extern int32 ScreenMode, ScreenWidth, ScreenHeight, ScreenBPP, ForceSetup, UseMouse, UseJoystick;
 
-int startwin_run(void)
+int startwin_run(struct startwin_settings *settings)
 {
 	int retval;
 	

--- a/src/StartupWinController.game.m
+++ b/src/StartupWinController.game.m
@@ -415,7 +415,7 @@ int startwin_idle(void *v)
 extern char* grpfile;
 extern int32 ScreenMode, ScreenWidth, ScreenHeight, ScreenBPP, ForceSetup, UseMouse, UseJoystick;
 
-int startwin_run(struct startwin_settings *settings)
+int startwin_run(struct startwin_settings *settingsignored)
 {
 	int retval;
 	

--- a/src/game.c
+++ b/src/game.c
@@ -931,7 +931,7 @@ static char const * *netparam = NULL;
 int nextvoxid = 0;  // JBF
 static const char *deffile = "sw.def";
 
-extern int startwin_run(void);
+extern int startwin_run(struct startwin_settings *settings);
 
 VOID
 InitGame(VOID)
@@ -3553,7 +3553,7 @@ int app_main(int argc, char const * const argv[])
 
 #if defined RENDERTYPEWIN || (defined RENDERTYPESDL && (defined __APPLE__ || defined HAVE_GTK2))
     if (i < 0 || ForceSetup || CommandSetup) {
-        if (quitevent || !startwin_run()) {
+        if (quitevent || !startwin_run(NULL)) {
             uninitengine();
             exit(0);
         }

--- a/src/game.c
+++ b/src/game.c
@@ -931,7 +931,7 @@ static char const * *netparam = NULL;
 int nextvoxid = 0;  // JBF
 static const char *deffile = "sw.def";
 
-extern int startwin_run(struct startwin_settings *settings);
+extern int startwin_run(struct startwin_settings *settingsignored);
 
 VOID
 InitGame(VOID)

--- a/src/menus.c
+++ b/src/menus.c
@@ -1208,7 +1208,7 @@ static BOOL MNU_JoystickButtonsInitialise(MenuItem_p UNUSED(mitem))
     joybuttonssetupgroup.items = joybuttons_i[0];
     item = &joybuttons_i[0][0];
 
-    for (button = 0; button < joynumbuttons * 2 + (joynumhats > 0) * 4; ) {
+    for (button = 0; button < joynumbuttons * 2; ) {
         if (button < joynumbuttons * 2) {
             int dbutton = button / 2;
 
@@ -1269,10 +1269,10 @@ static BOOL MNU_JoystickButtonsInitialise(MenuItem_p UNUSED(mitem))
             button++;
         }
 
-        if (pageitem == JOYSTICKITEMSPERPAGE || button == joynumbuttons * 2 + (joynumhats > 0) * 4) {
+        if (pageitem == JOYSTICKITEMSPERPAGE || button == joynumbuttons * 2) {
             // next page
             sprintf(JoystickButtonPageName[page], "Page %d / %d", page+1,
-                ((joynumbuttons * 2 + (joynumhats > 0) * 4) / JOYSTICKITEMSPERPAGE) + 1);
+                ((joynumbuttons * 2) / JOYSTICKITEMSPERPAGE) + 1);
 
             temppagename.text = JoystickButtonPageName[page];
             memcpy(item, &temppagename, sizeof(MenuItem));
@@ -1356,7 +1356,7 @@ static BOOL MNU_JoystickButtonSetupCustom(UserCall call, MenuItem *item)
 
 static BOOL MNU_JoystickButtonNextPage(void)
 {
-    JoystickButtonPage = (JoystickButtonPage + 1) % (((joynumbuttons * 2 + (joynumhats > 0) * 4) / JOYSTICKITEMSPERPAGE) + 1);
+    JoystickButtonPage = (JoystickButtonPage + 1) % (((joynumbuttons * 2) / JOYSTICKITEMSPERPAGE) + 1);
     joybuttonssetupgroup.items = &joybuttons_i[JoystickButtonPage][0];
     joybuttonssetupgroup.cursor = 0;
     MNU_ItemPreProcess(&joybuttonssetupgroup);

--- a/src/startgtk.game.c
+++ b/src/startgtk.game.c
@@ -708,7 +708,7 @@ int startwin_idle(void *s)
 extern int32 ScreenMode, ScreenWidth, ScreenHeight, ScreenBPP, ForceSetup, UseMouse, UseJoystick;
 extern char *grpfile;   // game.c
 
-int startwin_run(void)
+int startwin_run(struct startwin_settings *settings)
 {
     if (!gtkenabled) return 0;
     if (!startwin) return 1;

--- a/src/startgtk.game.c
+++ b/src/startgtk.game.c
@@ -708,7 +708,7 @@ int startwin_idle(void *s)
 extern int32 ScreenMode, ScreenWidth, ScreenHeight, ScreenBPP, ForceSetup, UseMouse, UseJoystick;
 extern char *grpfile;   // game.c
 
-int startwin_run(struct startwin_settings *settings)
+int startwin_run(struct startwin_settings *settingsignored)
 {
     if (!gtkenabled) return 0;
     if (!startwin) return 1;

--- a/src/startwin.game.c
+++ b/src/startwin.game.c
@@ -559,7 +559,7 @@ int startwin_idle(void *v)
 
 extern char *grpfile;	// game.c
 
-int startwin_run(void)
+int startwin_run(struct startwin_settings *settings)
 {
 	MSG msg;
 	if (!startupdlg) return 1;

--- a/src/startwin.game.c
+++ b/src/startwin.game.c
@@ -559,7 +559,7 @@ int startwin_idle(void *v)
 
 extern char *grpfile;	// game.c
 
-int startwin_run(struct startwin_settings *settings)
+int startwin_run(struct startwin_settings *settingsignored)
 {
 	MSG msg;
 	if (!startupdlg) return 1;


### PR DESCRIPTION
In the forum thread at https://lb.raspberrypi.org/forums/viewtopic.php?t=197981 we got JFSW running on the Raspberry Pi 3B+.

Other than automating the selection of NOASM, other fixes involve making this compatible with the latest jfbuild i.e. matching the new signature of `startwin_run()` and the removal of `joynumhats`. These should help on x86 Linux as well, including fixing #18.