### PR TITLE
Rename PREFIX to DATADIR to avoid confusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 RELEASE ?= 1
 
 # Base path of app installation
-PREFIX ?= /usr/local/share/games/jfsw
+DATADIR ?= /usr/local/share/games/jfsw
 
 # Engine source code path
 EROOT ?= jfbuild
@@ -207,7 +207,7 @@ OURCFLAGS+= $(BUILDCFLAGS)
 LIBS+= $(BUILDLIBS)
 
 ifneq ($(PLATFORM),WINDOWS)
-	OURCFLAGS+= -DPREFIX=\"$(PREFIX)\"
+	OURCFLAGS+= -DDATADIR=\"$(DATADIR)\"
 endif
 
 .PHONY: clean all engine $(ELIB)/$(ENGINELIB) $(ELIB)/$(EDITORLIB) $(AUDIOLIBROOT)/$(JFAUDIOLIB)

--- a/src/game.c
+++ b/src/game.c
@@ -3405,9 +3405,9 @@ int app_main(int argc, char const * const argv[])
     }
 #endif
 
-#if defined(PREFIX)
+#if defined(DATADIR)
     {
-        const char *prefixdir = PREFIX;
+        const char *prefixdir = DATADIR;
         if (prefixdir && prefixdir[0]) {
             addsearchpath(prefixdir);
         }


### PR DESCRIPTION
PREFIX is only used to access game data (and does not serve as a target PREFIX for installations), so rename it to DATADIR to avoid confusion.

This pull request is tied to the same one in the jfbuild repo.