### PR TITLE
CallbackSOsink big endian fix

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -1783,7 +1783,11 @@ SHRAP_USER_DEFINED      = 99
 typedef struct
     {
     int dist, flags;
+#if B_BIG_ENDIAN != 0
+    short depth, depth_fract; // do NOT change this, doubles as a long FIXED point number
+#else
     short depth_fract, depth; // do NOT change this, doubles as a long FIXED point number
+#endif
     short stag,    // ST? tag number - for certain things it helps to know it
         ang,
         height,

--- a/src/track.c
+++ b/src/track.c
@@ -2300,7 +2300,11 @@ void CallbackSOsink(ANIMp ap, void *data)
             // Added a depth_fract to the struct so I could do a
             // 16.16 Fixed point representation to change the depth
             // in a more precise way
+#if B_BIG_ENDIAN != 0
+            ndx = AnimSet((int*)&su->depth, tgt_depth<<16, (ap->vel<<8)>>8);
+#else
             ndx = AnimSet((int*)&su->depth_fract, tgt_depth<<16, (ap->vel<<8)>>8);
+#endif
             AnimSetVelAdj(ndx, ap->vel_adj);
             found = TRUE;
             break;


### PR DESCRIPTION
CallbackSOsink treats two successive short ints (depth_fract and depth) in the SECT_USER struct as a single 16.16 fixed point number. It assumed little endian byte order between the two shorts, which caused the sinking boat at the beginning of Rising Son to be glitchy on big endian platforms. 